### PR TITLE
Update pcre (Perl Compatible Regular Expressions) URI

### DIFF
--- a/scripts/build_nginx.sh
+++ b/scripts/build_nginx.sh
@@ -17,7 +17,7 @@ PCRE_VERSION=${PCRE_VERSION:-"8.39"}
 ZLIB_VERSION=${ZLIB_VERSION:-"1.2.11"}
 
 nginx_tarball_url=http://nginx.org/download/nginx-${NGINX_VERSION}.tar.gz
-pcre_tarball_url=ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre-${PCRE_VERSION}.tar.gz
+pcre_tarball_url=https://ftp.pcre.org/pub/pcre/pcre-${PCRE_VERSION}.tar.gz
 zlib_url=http://www.zlib.net/zlib-${ZLIB_VERSION}.tar.gz
 
 temp_dir=$(mktemp -d /tmp/nginx.XXXXXXXXXX)


### PR DESCRIPTION
The previous URI gave a null response, and so heroku build would fail.